### PR TITLE
slight tooling improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,14 @@ Build.bat
 /Makefile
 /Makefile.old
 /MANIFEST.bak
+/MANIFEST.SKIP.bak
 /META.yml
 /META.json
 /MYMETA.*
 nytprof.out
 /pm_to_blib
+*.c
 *.o
 *.bs
+Unicode-Casing-*/
+Unicode-Casing-*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+language: perl
+perl:
+# - '5.24'  TODO - not yet available
+- '5.22'
+- '5.20'
+- '5.18'
+- '5.16'
+- '5.14'
+- '5.12'
+- '5.10'
+install:
+- cpanm -n -q
+  Test::More
+  ExtUtils::Depends
+  B::Hooks::OP::PPAddr
+  B::Hooks::OP::Check
+script:
+  "perl Makefile.PL && make test"

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,8 +1,12 @@
 Casing.xs
 Changes
 lib/Unicode/Casing.pm
+LICENSE
 Makefile.PL
 MANIFEST
+MANIFEST.SKIP
+META.json
+META.yml
 ppport.h
 README
 t/01basic.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -3,5 +3,6 @@
 .*\.bs
 .*\.c
 .*\.o
+\.travis.yml
 Unicode-Casing-.*/
 Unicode-Casing-.*.tar.gz

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,7 @@
+#!include_default
+
+.*\.bs
+.*\.c
+.*\.o
+Unicode-Casing-.*/
+Unicode-Casing-.*.tar.gz

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ WriteMakefile(
     AUTHOR            => 'Karl Williamson <khw@cpan.org>',
     META_MERGE        => {
                            "meta-spec" => { version => 2 },
+                           dynamic_config => 0,
                            resources => {
                                repository => {
                                    type => 'git',


### PR DESCRIPTION
I saw https://rt.cpan.org/Ticket/Display.html?id=114396.

When releasing, make sure to upgrade ExtUtils::MakeMaker and CPAN::Meta to their latest versions; the commands I use for releasing vanilla EUMM-based dists is: `perl Makefile.PL && make manifest && make test && make dist`; then after inspecting the contents of the tarball, `cpan-upload Foo-0.001.tar.gz`
